### PR TITLE
Optionally track analytics for hardware versions of providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+.idea
+
 /registration_relay

--- a/cmd/registration_relay/main.go
+++ b/cmd/registration_relay/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/beeper/libserv/pkg/flagenv"
 
+	"github.com/beeper/registration-relay/internal/analytics"
 	"github.com/beeper/registration-relay/internal/api"
 	"github.com/beeper/registration-relay/internal/config"
 	"github.com/beeper/registration-relay/internal/metrics"
@@ -46,6 +47,17 @@ func main() {
 		"Validate auth header URL",
 	)
 
+	analyticsURL := flag.String(
+		"analyticsURL",
+		flagenv.StringEnvWithDefault("ANALYTICS_URL", ""),
+		"URL to send analytics to, disabled by default",
+	)
+	analyticsToken := flag.String(
+		"analyticsToken",
+		flagenv.StringEnvWithDefault("ANALYTICS_TOKEN", ""),
+		"Write key to auth analytics with, disabled by default",
+	)
+
 	flag.Parse()
 
 	if *prettyLogs {
@@ -66,6 +78,9 @@ func main() {
 		log.Fatal().Err(err).Int("secret_len", len(cfg.Secret)).Msg("Invalid secret")
 	}
 	cfg.API.ValidateAuthURL = *validateAuthURL
+
+	analytics.ConfigURL = *analyticsURL
+	analytics.ConfigToken = *analyticsToken
 
 	log.Info().Str("commit", Commit).Str("build_time", BuildTime).Msg("registration-relay starting")
 

--- a/internal/analytics/analytics.go
+++ b/internal/analytics/analytics.go
@@ -1,0 +1,58 @@
+package analytics
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+var ConfigURL = ""
+var ConfigToken = ""
+var client http.Client
+
+var logger = log.With().Str("component", "analytics").Logger()
+
+func trackImplementation(userId string, event string, properties map[string]any) {
+	var buf bytes.Buffer
+	err := json.NewEncoder(&buf).Encode(map[string]interface{}{
+		"userId":     userId,
+		"event":      event,
+		"properties": properties,
+	})
+	if err != nil {
+		logger.Error().Err(err).Msg("error encoding payload")
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, ConfigURL, &buf)
+	if err != nil {
+		logger.Error().Err(err).Msg("error creating request")
+		return
+	}
+	req.SetBasicAuth(ConfigToken, "")
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Error().Err(err).Msg("error sending request")
+		return
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		logger.Error().Err(err).Msg("error closing request")
+	}
+
+	logger.Info().Str("event", event).Msg("Tracked event")
+}
+
+func IsEnabled() bool {
+	return len(ConfigToken) > 0
+}
+
+func Track(userId string, event string, properties map[string]any) {
+	if !IsEnabled() {
+		return
+	}
+
+	go trackImplementation(userId, event, properties)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/beeper/registration-relay/internal/analytics"
 	"sync"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
+	"github.com/beeper/registration-relay/internal/analytics"
 	"github.com/beeper/registration-relay/internal/metrics"
 	"github.com/beeper/registration-relay/internal/util"
 )

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -6,9 +6,15 @@ type RawCommand[T any] struct {
 	Data    T      `json:"data"`
 }
 
+type versions struct {
+	HardwareVersion string `json:"hardware_version"`
+}
+
 type registerCommandData struct {
-	Code   string `json:"code"`
-	Secret string `json:"secret"`
+	Code     string   `json:"code"`
+	Secret   string   `json:"secret"`
+	Commit   string   `json:"commit,omitempty"`
+	Versions versions `json:"versions,omitempty"`
 }
 
 type errorData struct {


### PR DESCRIPTION
Goes with https://github.com/beeper/mac-registration-provider/pull/20